### PR TITLE
Add support for Windows via rwinlib

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^.gitignore
 ^.Rhistory
 ^inst/.DS_S*
+^windows$

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 src/*.o
 src/*.so
 src/*.dll
+windows

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,0 +1,2 @@
+CRT=-ucrt
+include Makevars.win

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,3 +1,14 @@
-CXX=clang++
-PKG_CPPFLAGS= -I$(MINGW_PREFIX)/include/
-PKG_LIBS= $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) -lsbml -lbz2 -lz -lxml2 -liconv -lws2_32
+VERSION=5.19.0
+RWINLIB=../windows/libsbml-$(VERSION)
+PKG_CPPFLAGS= -I$(RWINLIB)/include/
+PKG_LIBS= -L$(RWINLIB)/lib$(R_ARCH)$(CRT) -lsbml -lbz2 -lz -lxml2 -liconv -lws2_32
+
+all: clean winlibs
+
+clean:
+	rm -f $(SHLIB) $(OBJECTS)
+
+winlibs: clean
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R" $(VERSION)
+
+.PHONY: all winlibs clean

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,0 +1,10 @@
+# Build against mingw-w64 build of libsbml
+VERSION <- commandArgs(TRUE)
+if(!file.exists(sprintf("../windows/libsbml-%s/include/sbml/SBMLTypes.h", VERSION))){
+  if(getRversion() < "3.3.0") setInternet2()
+  download.file(sprintf("https://github.com/rwinlib/libsbml/archive/v%s.zip", VERSION),
+                "lib.zip", quiet = TRUE)
+  dir.create("../windows", showWarnings = FALSE)
+  unzip("lib.zip", exdir = "../windows")
+  unlink("lib.zip")
+}


### PR DESCRIPTION
Makes the package build on any windows machine, by automatically downloading the required libsbml libraries. 

This is how almost all packages do it: https://github.com/search?q=org%3Acran+rwinlib&type=code